### PR TITLE
Rename Prometheus metrics

### DIFF
--- a/main.go
+++ b/main.go
@@ -115,7 +115,7 @@ func callRevtr(client *revtrpb.RevtrClient, revtrMeasurements []*revtrpb.RevtrMe
 		CheckDB: false,
 	})
 	if err != nil {
-		revtrAPICallsMetric.WithLabelValues("failed").Inc()
+		revtrAPICallsMetric.WithLabelValues("error").Inc()
 		logger.Error(err)
 	}
 	revtrAPICallsMetric.WithLabelValues("success").Inc()


### PR DESCRIPTION
This PR renames the Prometheus metrics exposed by revtr-sidecar to conform to the [metric and label naming guidelines:](https://prometheus.io/docs/practices/naming/)
- `revtr_api_calls_total{status}`: includes both success and failure via the `status` label, more precise error descriptions might be added (right now status=success|error)
- `revtr_samples_total`

(The whitespace/formatting changes have all been done automatically by [gofmt](https://pkg.go.dev/cmd/gofmt))