### PR TITLE
Add newRevtrMeasurement(src, dst, uuid)

### DIFF
--- a/main.go
+++ b/main.go
@@ -300,20 +300,16 @@ func refreshMLabNodes(h *handler) {
 	}
 	h.mlabIPToSiteLock.Unlock()
 
-	for {
-		select {
-		case <-t.C:
-			log.Infof("Refreshing MLab nodes")
-			h.mlabIPToSiteLock.Lock()
-			mlabIPtoSite, err := getMLabNodes(url)
-			if err != nil {
-				log.Error(err)
-			} else {
-				h.mlabIPtoSite = mlabIPtoSite
-			}
-			h.mlabIPToSiteLock.Unlock()
-
+	for _ = range t.C {
+		log.Infof("Refreshing MLab nodes")
+		h.mlabIPToSiteLock.Lock()
+		mlabIPtoSite, err := getMLabNodes(url)
+		if err != nil {
+			log.Error(err)
+		} else {
+			h.mlabIPtoSite = mlabIPtoSite
 		}
+		h.mlabIPToSiteLock.Unlock()
 	}
 
 }


### PR DESCRIPTION
This PR moves the code for creating a `revtrMeasurement` with custom src, dst and uuid to its own constructor func. It should be functionally equivalent to the previous version, except for these lines that copied a mutex, causing a go staticcheck warning:
 
```
revtrMeasurementToSend := new(revtrpb.RevtrMeasurement)
*revtrMeasurementToSend = revtrMeasurement
```

Also, a select with a single case is replaced with the `for _ = range chan` syntax, to fix another staticcheck warning.