### PR TITLE
Add histogram metrics for API call time and eventsocket polling

### DIFF
--- a/main.go
+++ b/main.go
@@ -129,7 +129,7 @@ func callRevtr(client *revtrpb.RevtrClient, revtrMeasurements []*revtrpb.RevtrMe
 		CheckDB: false,
 	})
 	elapsed := time.Since(start)
-	log.Debugf("revtr API request took %d us", elapsed.Milliseconds())
+	log.Debugf("revtr API request took %d ms", elapsed.Milliseconds())
 	revtrAPIRequestDurationHist.Observe(elapsed.Seconds())
 	if err != nil {
 		revtrAPICallsMetric.WithLabelValues("error").Inc()


### PR DESCRIPTION
This PR adds two histogram metrics:
- revtr_api_request_duration_seconds - time to call the revtr API 
- revtr_eventsocket_polling_duration_seconds - time to process an event from the event socket