### PR TITLE
Add event processing time metric

### DIFF
--- a/main.go
+++ b/main.go
@@ -66,7 +66,7 @@ var (
 
 	revtrEventProcessingDurationHist = promauto.NewHistogram(prometheus.HistogramOpts{
 		Name:    "revtr_event_processing_duration_seconds",
-		Buckets: []float64{1, 2, 4, 8, 15},
+		Buckets: []float64{2, 4, 6, 8, 10, 12, 14, 16},
 		Help:    "Reverse Traceroute end-to-end event processing duration",
 	})
 


### PR DESCRIPTION
This PR replaces `revtr_eventsocket_polling_duration_seconds` with `revtr_event_processing_duration_seconds`. This new metric measures the "total time between the instant the event is generated by tcp-info and the instant the same event is sent to the revtr API server". 

To do this, I had to refactor the code a bit to get the `timestamp` field to `callRevtr`.